### PR TITLE
Fix undefined subitems by adding null coalescing operator

### DIFF
--- a/contao/templates/navigation/nav_mega_menu_default.html5
+++ b/contao/templates/navigation/nav_mega_menu_default.html5
@@ -15,7 +15,7 @@
                     ?>
                     <?= Generator::generate($item['id']) ?>
                 <?php else: ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
             </li>
         <?php else: ?>
@@ -28,7 +28,7 @@
                     ?>
                     <?= Generator::generate($item['id']) ?>
                 <?php else: ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
             </li>
         <?php endif; ?>

--- a/contao/templates/navigation/nav_mega_menu_default_noHover_justClick.html5
+++ b/contao/templates/navigation/nav_mega_menu_default_noHover_justClick.html5
@@ -16,7 +16,7 @@ use Derhaeuptling\ContaoMegaMenu\Generator\Generator;
                     ?>
                     <?= Generator::generate($item['id']) ?>
                 <?php else : ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
             </li>
         <?php else : ?>
@@ -36,7 +36,7 @@ use Derhaeuptling\ContaoMegaMenu\Generator\Generator;
                     ?>
                     <?= Generator::generate($item['id']) ?>
                 <?php else : ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
                 </li>
             <?php endif; ?>

--- a/contao/templates/navigation/nav_mega_menu_default_outside.html5
+++ b/contao/templates/navigation/nav_mega_menu_default_outside.html5
@@ -12,7 +12,7 @@ use Derhaeuptling\ContaoMegaMenu\Generator\Generator;
                 <?php if (Generator::has($item['id'])): ?>
                     <?php Generator::addOutsider(Generator::generate($item['id'])) ?>
                 <?php else: ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
             </li>
         <?php else: ?>
@@ -22,7 +22,7 @@ use Derhaeuptling\ContaoMegaMenu\Generator\Generator;
                 <?php if (Generator::has($item['id'])): ?>
                     <?php Generator::addOutsider(Generator::generate($item['id'])) ?>
                 <?php else: ?>
-                    <?= $item['subitems'] ?>
+                    <?= $item['subitems'] ?? '' ?>
                 <?php endif; ?>
             </li>
         <?php endif; ?>


### PR DESCRIPTION
Replaced direct access to `$item['subitems']` with `$item['subitems'] ?? ''` to prevent potential undefined index errors. This ensures stability and prevents runtime issues when `subitems` is not set. Applied changes consistently across all relevant templates.

Fixes https://github.com/DERHAEUPTLING/contao-mega-menu/issues/20